### PR TITLE
Changed etcd docker image repo

### DIFF
--- a/kubernetes/docker-compose.yml
+++ b/kubernetes/docker-compose.yml
@@ -1,5 +1,5 @@
 etcd:
-  image: gcr.io/google_containers/etcd:2.2.1
+  image: quay.io/coreos/etcd:v2.3.1
   net: host
   command: ['/usr/local/bin/etcd', '--addr=127.0.0.1:4001', '--bind-addr=0.0.0.0:4001', '--data-dir=/var/etcd/data']
 


### PR DESCRIPTION
As etcd current releases are available only on quay.io, the actual URL of Docker registry has been updated (from gcr.io to quay.io).
Also, etcd version updated to the latest one (v2.3.1)
